### PR TITLE
set system=>true on non human user accounts

### DIFF
--- a/manifests/administration.pp
+++ b/manifests/administration.pp
@@ -4,6 +4,7 @@ class openerp::administration (
 
   group { 'openerp-admin':
     ensure => present,
+    system => true,
   }
 
   sudo::directive { 'openerp-administration':

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -5,6 +5,7 @@ class openerp::base($groups=['dialout','postgres','adm']) {
     shell      => '/bin/bash',
     home       => '/srv/openerp',
     managehome => true,
+    system     => true,
     groups     => $groups,
     require    => Package['postgresql']
   }


### PR DESCRIPTION
This is important to avoid uid/gid conflicts with accounts created
with fixed uids in normal user range.

This patch won't break existing configs because it only influences the
uid generation on new user / group creation and has no impact on existing
resources.
