### PR TITLE
openerp module compatibility with debian wheezy

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 class openerp($groups=['dialout','postgres']) {
-  if $::lsbdistcodename != 'squeeze' {
+  if $::lsbdistcodename !~ /^(squeeze|wheezy)$/ {
     fail "Unsupported system ${::lsbdistcodename}"
   }
 


### PR DESCRIPTION
Wheezy added in init.pp to support wheezy (the modules required by puppet-openerp are already compatible with wheezy)
